### PR TITLE
feat(core): Task Activity Page No Longer Shows Correct Links

### DIFF
--- a/scaffolder-templates/microservice-repo-bootstrap/template.yaml
+++ b/scaffolder-templates/microservice-repo-bootstrap/template.yaml
@@ -194,12 +194,12 @@ spec:
         catalogInfoPath: "/catalog-info.yml"
         optional: true
 
-  output:
-    remoteUrl: ${{ steps.publish.output.remoteUrl }}
-    entityRef: ${{ steps.register.output.entityRef }}
+  output:    
     links:
       - title: Repository
         url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps['register'].output.entityRef }}
+    remoteUrl: ${{ steps.publish.output.remoteUrl }}
+    entityRef: ${{ steps.register.output.entityRef }}

--- a/scaffolder-templates/microservice-repo-bootstrap/template.yaml
+++ b/scaffolder-templates/microservice-repo-bootstrap/template.yaml
@@ -197,9 +197,9 @@ spec:
   output:    
     links:
       - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
+        url: ${{ steps.publish.output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps['register'].output.entityRef }}
+        entityRef: ${{ steps.register.output.entityRef }}
     remoteUrl: ${{ steps.publish.output.remoteUrl }}
     entityRef: ${{ steps.register.output.entityRef }}

--- a/scaffolder-templates/microservice-repo-bootstrap/template.yaml
+++ b/scaffolder-templates/microservice-repo-bootstrap/template.yaml
@@ -186,14 +186,20 @@ spec:
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         
-    # - id: register
-    #   name: Register
-    #   action: catalog:register
-    #   input:
-    #     repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-    #     catalogInfoPath: "/catalog-info.yml"
-    #     optional: true
+    - id: register
+      name: Register
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        catalogInfoPath: "/catalog-info.yml"
+        optional: true
 
   output:
+    links:
+      - title: Repository
+        url: ${{ steps.publish.output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}
     remoteUrl: ${{ steps.publish.output.remoteUrl }}
     entityRef: ${{ steps.register.output.entityRef }}

--- a/scaffolder-templates/microservice-repo-bootstrap/template.yaml
+++ b/scaffolder-templates/microservice-repo-bootstrap/template.yaml
@@ -186,18 +186,14 @@ spec:
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         
-    - id: register
-      name: Register
-      action: catalog:register
-      input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: "/catalog-info.yml"
-        optional: true
+    # - id: register
+    #   name: Register
+    #   action: catalog:register
+    #   input:
+    #     repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+    #     catalogInfoPath: "/catalog-info.yml"
+    #     optional: true
 
-  output:    
-    links:
-      - title: Repository
-        url: ${{ steps.publish.output.remoteUrl }}
-      - title: Open in catalog
-        icon: catalog
-        entityRef: ${{ steps.register.output.entityRef }}
+  output:
+    remoteUrl: ${{ steps.publish.output.remoteUrl }}
+    entityRef: ${{ steps.register.output.entityRef }}

--- a/scaffolder-templates/microservice-repo-bootstrap/template.yaml
+++ b/scaffolder-templates/microservice-repo-bootstrap/template.yaml
@@ -197,3 +197,9 @@ spec:
   output:
     remoteUrl: ${{ steps.publish.output.remoteUrl }}
     entityRef: ${{ steps.register.output.entityRef }}
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}

--- a/scaffolder-templates/microservice-repo-bootstrap/template.yaml
+++ b/scaffolder-templates/microservice-repo-bootstrap/template.yaml
@@ -201,5 +201,3 @@ spec:
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps.register.output.entityRef }}
-    remoteUrl: ${{ steps.publish.output.remoteUrl }}
-    entityRef: ${{ steps.register.output.entityRef }}


### PR DESCRIPTION
Task Activity Page No Longer Shows Correct Links

[ARC-102](https://github.com/sourcefuse/backstage/issues/102)

## Description
Following the branding, the Task Activity page is missing the links to the Backstage catalog and GitHub for the newly created component.
The Task Activity page no longer shows the links to the Backstage catalog info and GitHub repo.

To resolve above issue, we should add links in output for each template. This is the PR where I updated template.yaml file to add catalog and repo links in output. We need to make same changes in other templates as well.
![image](https://github.com/sourcefuse/sf-software-templates/assets/109595269/a675b6f9-a0cf-4890-9ee6-6110a6a74647)
![image](https://github.com/sourcefuse/sf-software-templates/assets/109595269/32fabadb-e9ff-47a8-94e5-0a28d2f90aaf)
![image](https://github.com/sourcefuse/sf-software-templates/assets/109595269/62ee6ca6-afd3-435e-889a-9d9d6f505ba6)

Fixes # (issue)
[ARC-102](https://github.com/sourcefuse/backstage/issues/102)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules

[ARC-102]: https://sourcefuse.atlassian.net/browse/ARC-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARC-102]: https://sourcefuse.atlassian.net/browse/ARC-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ